### PR TITLE
Feature #87 Do not display data-testid in production（本番環境でdata-testidを表示しないようにする）

### DIFF
--- a/next.config.cjs
+++ b/next.config.cjs
@@ -13,6 +13,9 @@ const nextConfig = {
     }
     return config;
   },
+  compiler: {
+    reactRemoveProperties: process.env.NODE_ENV === 'production' ? { properties: ['^data-testid$'] } : false,
+  },
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
## Overview（概要）

- 本番環境でdata-testidを表示しないようにする

## Type of change（変更内容）

- `next.config.cjs`にdata-testidを除外する設定を追加

## Checklist（チェックリスト）

- [x] The title of the pull request is described.（タイトルが記載されている）
- [x] The overview is written.（概要が記載されいてる）
- [x] The label iis set correctly.（ラベルが正しくセットされている）

## Supplement（補足）

-
